### PR TITLE
Enable -W, -Werror, and -O for Exercises

### DIFF
--- a/Exercises/Exercises.cabal
+++ b/Exercises/Exercises.cabal
@@ -38,7 +38,7 @@ test-suite Exercises-test
       Paths_Exercises
   hs-source-dirs:
       test
-  ghc-options: -rtsopts -threaded -with-rtsopts=-N
+  ghc-options: -O -rtsopts -threaded -W -Werror -with-rtsopts=-N
   build-depends:
       Exercises
     , base >=4.7 && <5

--- a/Exercises/Exercises.cabal
+++ b/Exercises/Exercises.cabal
@@ -21,6 +21,7 @@ library
       Paths_Exercises
   hs-source-dirs:
       src
+  ghc-options: -O -rtsopts -threaded -W -Werror -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
   default-language: Haskell2010

--- a/Exercises/package.yaml
+++ b/Exercises/package.yaml
@@ -12,8 +12,11 @@ tests:
     main: TestMain.hs
     source-dirs: test
     ghc-options:
+      - -O
       - -rtsopts
       - -threaded
+      - -W
+      - -Werror
       - -with-rtsopts=-N
     dependencies:
       - Exercises

--- a/Exercises/package.yaml
+++ b/Exercises/package.yaml
@@ -6,6 +6,13 @@ dependencies:
 
 library:
   source-dirs: src
+  ghc-options:
+    - -O
+    - -rtsopts
+    - -threaded
+    - -W
+    - -Werror
+    - -with-rtsopts=-N
 
 tests:
   Exercises-test:

--- a/Exercises/src/List.hs
+++ b/Exercises/src/List.hs
@@ -1,8 +1,6 @@
 module List
 where
 
-import Control.Applicative (liftA2)
-
 data List a = End | List a (List a)
   deriving (Eq)
 
@@ -28,8 +26,8 @@ instance Functor List where
 instance Applicative List where
   pure x = List x End
 
-  End <*> xs  = End
-  fs  <*> End = End
+  End <*> _   = End
+  _   <*> End = End
   List f fs <*> xs = (f <$> xs) <> (fs <*> xs)
 
 instance Monad List where

--- a/Exercises/src/Tree.hs
+++ b/Exercises/src/Tree.hs
@@ -5,7 +5,7 @@ data Tree a = Nil | Tree a (Tree a) (Tree a)
   deriving (Eq, Show)
 
 instance Functor Tree where
-  fmap f Nil = Nil
+  fmap _ Nil = Nil
   fmap f (Tree x left right) = Tree (f x) (fmap f left) (fmap f right)
 
 instance Foldable Tree where

--- a/Exercises/test/Tests/EquilibriumIndex.hs
+++ b/Exercises/test/Tests/EquilibriumIndex.hs
@@ -1,7 +1,6 @@
 module Tests.EquilibriumIndex where
 
 import EquilibriumIndex
-import Test.Tasty
 import Test.Tasty.HUnit
 import Tests.Helpers
 

--- a/Exercises/test/Tests/FallingWater.hs
+++ b/Exercises/test/Tests/FallingWater.hs
@@ -1,7 +1,6 @@
 module Tests.FallingWater where
 
 import FallingWater
-import Test.Tasty
 import Test.Tasty.HUnit
 import Tests.Helpers
 

--- a/Exercises/test/Tests/List.hs
+++ b/Exercises/test/Tests/List.hs
@@ -3,7 +3,6 @@ module Tests.List where
 import Data.Functor.Compose
 import Data.Functor.Identity
 import List
-import Test.Tasty
 import Test.Tasty.HUnit
 import Tests.Helpers
 

--- a/Exercises/test/Tests/SpiralMatrix.hs
+++ b/Exercises/test/Tests/SpiralMatrix.hs
@@ -1,7 +1,6 @@
 module Tests.SpiralMatrix where
 
 import SpiralMatrix
-import Test.Tasty
 import Test.Tasty.HUnit
 import Tests.Helpers
 

--- a/Exercises/test/Tests/Tree.hs
+++ b/Exercises/test/Tests/Tree.hs
@@ -1,7 +1,6 @@
 module Tests.Tree where
 
 import Tree
-import Test.Tasty
 import Test.Tasty.HUnit
 import Tests.Helpers
 


### PR DESCRIPTION
- Enable `-W` and `-Werror` to find some warnings.
- Fix warnings.
- Enable `-O` for optimizations.  This doesn't seem to improve running time or change compilation time much right now.  But, this turns on [demand analysis](https://downloads.haskell.org/ghc/latest/docs/users_guide/using-optimisation.html), which will prevent foot-shooting from making everything lazy by default (e.g. the `foldl` vs. `foldl'` problem).